### PR TITLE
Update index.php

### DIFF
--- a/public_html/index.php
+++ b/public_html/index.php
@@ -29,6 +29,7 @@ $app->notFound(function () use ($app) {
 });
 
 $pi = PiFaceDigital::create();
+$pi->init();   // Bug fixed: Missing initialization. Without this line, a COLD boot of Pi would give incorrect result. 
 
 // Defining min/max values
 \Slim\Route::setDefaultConditions(array(


### PR DESCRIPTION
A COLD restart of Pi would give incorrect result without the init(). To replicate the issue, power off Pi version 1 and power it up again, then immediately go to the REST API and try to GET and SET some values, it will fail.   The interesting part is that.. only one time init() is necessary for the whole Pi system after cold boot. In other words, you can run another PHP file with Init(),  a Python script that triggers PiFace, or even simply launch PiFace Digital Emulator after cold boot. After that, it would give you the correct value until next cold boot.  I am not expert enough to say what happened but it seems like it triggers something at the background. But this simple line fixed the problem.